### PR TITLE
feat: added decorator hover documentation

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,6 @@
 const vscode = require('vscode');
 const path = require('path');
+const { metaflowHoverProvider, loadDecoratorMap } = require('./metaflowHoverProvider');
 
 let sharedTerminal = null;
 
@@ -56,7 +57,7 @@ async function runPythonCommand(scriptName) {
   */
 }
 
-function activate(context) {
+async function activate(context) {
   const runCmd = vscode.commands.registerCommand(
     'extension.runPythonFunction',
     () => runPythonCommand('run_func')
@@ -68,6 +69,16 @@ function activate(context) {
   );
 
   context.subscriptions.push(runCmd, spinCmd);
+  
+  // Hover provider
+  const hoverDisposable = vscode.languages.registerHoverProvider(
+    { scheme: 'file', language: 'python' },
+    metaflowHoverProvider
+  );
+  context.subscriptions.push(hoverDisposable);
+  
+  await loadDecoratorMap(context);
+
 }
 
 function deactivate() {

--- a/metaflowHoverProvider.js
+++ b/metaflowHoverProvider.js
@@ -1,0 +1,110 @@
+const vscode = require('vscode');
+const path   = require('path');
+const cp     = require('child_process');
+
+const INTROSPECT_SCRIPT = path.join(__dirname, 'metaflow_introspect.py');
+let _decoratorMap = null;
+
+async function resolvePythonPath() {
+  try {
+    const pythonExt = vscode.extensions.getExtension('ms-python.python');
+    if (pythonExt) {
+      if (!pythonExt.isActive) await pythonExt.activate();
+      const api = pythonExt.exports;
+      if (api?.settings?.getExecutionDetails) {
+        const details = api.settings.getExecutionDetails();
+        if (details?.execCommand?.[0]) return details.execCommand[0];
+      }
+      if (api?.environments?.getActiveEnvironmentPath) {
+        const envPath = await api.environments.getActiveEnvironmentPath();
+        if (envPath?.path) return envPath.path;
+      }
+    }
+  } catch (_) {}
+
+  const fromSetting = vscode.workspace.getConfiguration('python').get('defaultInterpreterPath');
+  if (fromSetting && fromSetting !== 'python') return fromSetting;
+  return 'python3';
+}
+
+function runIntrospectionScript(pythonPath) {
+  return new Promise((resolve, reject) => {
+    cp.execFile(pythonPath, [INTROSPECT_SCRIPT], { timeout: 15_000 }, (err, stdout, stderr) => {
+      if (err) return reject(`Introspection failed:\n${stderr || err.message}`);
+      try {
+        const data = JSON.parse(stdout);
+        data.__error__ ? reject(data.__error__) : resolve(data);
+      } catch (e) {
+        reject(`Could not parse output: ${e.message}\nRaw: ${stdout.slice(0, 300)}`);
+      }
+    });
+  });
+}
+
+async function loadDecoratorMap(context) {
+  _decoratorMap = null;
+
+  const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+  status.text = '$(sync~spin) Metaflow: loading decorators…';
+  status.show();
+  context.subscriptions.push(status);
+
+  try {
+    const pythonPath = await resolvePythonPath();
+    _decoratorMap = await runIntrospectionScript(pythonPath);
+    status.text = `$(check) Metaflow: ${Object.keys(_decoratorMap).length} decorators loaded`;
+    setTimeout(() => status.hide(), 4000);
+  } catch (err) {
+    status.text = '$(warning) Metaflow: decorator introspection failed';
+    status.tooltip = String(err);
+    setTimeout(() => status.hide(), 8000);
+    console.error('[metaflow-hover]', err);
+  }
+}
+
+function buildTooltip(name, meta) {
+  const md = new vscode.MarkdownString('', true);
+  md.isTrusted = true;
+
+  md.appendMarkdown(`### \`@${name}\` _(${meta.kind} decorator)_\n\n`);
+  if (meta.summary) md.appendMarkdown(`${meta.summary}\n\n`);
+
+  const params = Object.entries(meta.params);
+  if (params.length === 0) {
+    md.appendMarkdown('_No parameters._\n\n');
+  } else {
+    md.appendMarkdown('**Parameters**\n\n');
+    md.appendMarkdown('| Name | Type | Default | Description |\n');
+    md.appendMarkdown('|------|------|---------|-------------|\n');
+    for (const [pName, p] of params) {
+      const def = p.default === null ? '`None`' : p.default === '' ? '`""`' : `\`${JSON.stringify(p.default)}\``;
+      md.appendMarkdown(`| \`${pName}\` | \`${p.type}\` | ${def} | ${p.doc || '—'} |\n`);
+    }
+    md.appendMarkdown('\n');
+  }
+
+  md.appendMarkdown(`[$(book) Open documentation](${meta.doc_url})\n`);
+  return md;
+}
+
+const metaflowHoverProvider = {
+  provideHover(document, position) {
+    if (!_decoratorMap) return;
+
+    const wordRange = document.getWordRangeAtPosition(position, /[a-zA-Z_][a-zA-Z0-9_]*/);
+    if (!wordRange) return;
+
+    const word = document.getText(wordRange);
+    if (!_decoratorMap[word]) return;
+
+    // Check character before word is '@'
+    const charBefore = wordRange.start.character > 0
+      ? document.getText(new vscode.Range(wordRange.start.translate(0, -1), wordRange.start))
+      : '';
+    if (charBefore !== '@') return;
+
+    return new vscode.Hover(buildTooltip(word, _decoratorMap[word]), wordRange);
+  }
+};
+
+module.exports = { loadDecoratorMap, metaflowHoverProvider };

--- a/metaflow_introspect.py
+++ b/metaflow_introspect.py
@@ -1,0 +1,96 @@
+import json
+import sys
+import inspect
+import re
+
+STEP_DECO_BASE = "https://docs.metaflow.org/api/step-decorators"
+FLOW_DECO_BASE = "https://docs.metaflow.org/api/flow-decorators"
+
+def build_doc_url(name, kind):
+    base = STEP_DECO_BASE if kind == "step" else FLOW_DECO_BASE
+    return f"{base}/{name}"
+
+def parse_param_docs(docstring):
+    if not docstring:
+        return {}
+    result = {}
+    for name, desc in re.findall(r"^\s{4,}(\w+)\s*(?:\([^)]*\))?\s*:\s*(.+)", docstring, re.MULTILINE):
+        result[name] = desc.strip()
+    for name, desc in re.findall(r":param\s+(?:\w+\s+)?(\w+)\s*:\s*(.+)", docstring):
+        result[name] = desc.strip()
+    return result
+
+def extract_summary(docstring):
+    if not docstring:
+        return ""
+    for line in docstring.splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+def type_label(value):
+    if value is None:
+        return "any"
+    return {
+        bool: "bool",
+        int: "int",
+        float: "float",
+        str: "str",
+        list: "list",
+        dict: "dict",
+        tuple: "tuple"
+    }.get(type(value), type(value).__name__)
+
+def introspect():
+    try:
+        import metaflow.decorators as mfd
+    except ImportError:
+        print(json.dumps({"__error__": "metaflow not found"}))
+        sys.exit(1)
+
+    result = {}
+    decoratorSet = set()
+
+    for kind, base in {"step": mfd.StepDecorator, "flow": mfd.FlowDecorator}.items():
+        for klass in base.__subclasses__():
+
+            name = getattr(klass, "name", None)
+
+            if not name or name in decoratorSet:
+                continue
+
+            if inspect.isabstract(klass) or name.endswith("_internal") or name == "NONAME":
+                continue
+
+            decoratorSet.add(name)
+
+            defaults = getattr(klass, "defaults", {}) or {}
+            docstring = inspect.getdoc(klass) or ""
+            param_docs = parse_param_docs(docstring)
+
+            result[name] = {
+                "kind": kind,
+                "params": {
+                    p: {
+                        "default": d,
+                        "type": type_label(d),
+                        "doc": param_docs.get(p, "")
+                    }
+                    for p, d in defaults.items()
+                },
+                "summary": extract_summary(docstring),
+                "doc_url": build_doc_url(name, kind),
+            }
+
+    result["step"] = {
+        "kind": "step",
+        "params": {},
+        "summary": "Marks a method as a Metaflow step in the flow DAG.",
+        "doc_url": build_doc_url("step", "step")
+    }
+
+    return result
+
+
+if __name__ == "__main__":
+    print(json.dumps(introspect(), indent=2, default=str))

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "engines": { "vscode": "^1.80.0" },
   "activationEvents": [
     "onCommand:extension.runPythonFunction",
-    "onCommand:extension.spinPythonFunction"
+    "onCommand:extension.spinPythonFunction", 
+    "onLanguage:python"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Closes Issue #8 
closes #8 
##  Feature description: 
- This PR adds hover tooltips for Metaflow decorators that display the decorator name, a short description, available parameters, and a link to the official documentation.
- Currently supports all the exposable decorators.

## Approach:-
- `metaflow_introspect.py` file extracts all valid decorators from metaflow. I've used a hybrid approach for extracting decorators because flow and step decorators can be accessed directly as they are subclasses of Flowdecorators and StepDecorators. But `@step` decorator is a special function. Hence this decorator has been added directly.
- `metaflowHoverProvider.js` file is to implement the hover functionality. Currently this file has multiple functions and this will be simplified in later. The main functions include extracting decorators, generating the tooltip ( have use md for this) and creating the hover provider. There is an additional function called `resolvePythonPath` to get the path of the function to make this extension run efficiently in any environment.
- modified `extension.js` so that the hover functionality can be used.
    

## Screenshots/Recordings:

<img width="516" height="194" alt="Screenshot 2026-03-06 at 11 39 34 PM" src="https://github.com/user-attachments/assets/cb7d18d3-942a-43d6-a78a-c8900ba6c45e" />

https://github.com/user-attachments/assets/560ed92e-465a-4211-bff0-db4278bedc92

